### PR TITLE
Fix time throttler miscalculating secs_passed

### DIFF
--- a/code/player.py
+++ b/code/player.py
@@ -202,7 +202,7 @@ class Player(object):
             self.raw_sec = self.raw_day * g.seconds_per_day
             self.update_times()
 
-        secs_passed = time_sec
+        secs_passed = self.raw_sec - old_time
         mins_passed = self.raw_min - last_minute
 
         time_of_day = g.pl.raw_sec % g.seconds_per_day


### PR DESCRIPTION
You forgot to adjust secs_passed correctly after throttling time per tick. This bug might be related to this issue https://github.com/singularity/singularity/issues/18, but I'm not sure.